### PR TITLE
Verification levels

### DIFF
--- a/json_files/config.json
+++ b/json_files/config.json
@@ -1,19 +1,20 @@
 {
-	"gensoc_server": 822411164846653490,
-	"verification_channel": 822423063697948693,
-	"this_or_that_channel": 1064462494753620010,
-	"counting_channel": 1134336873628696638,
-	"auction_channel": 1142007829478252554,
-	"welcome_channel": 822411164846653492,
-	"moderation_channel": 1167298366439428126,
-	"prev_welcome_message": 1164658878013776033,
-	"card_spam_channel": 882497725394989058,
-	"card_spam_counter": 6482,
-	"user_blacklist": [
-			1137757648071184444,
-			1149315540351983658,
-			1154774176515760210
-		],
-	"role_colour_shop": "https://unswgensoc.com/wp-content/uploads/2023/08/Colour-Role-Preview-1.png",
-	"role_icon_shop": "https://unswgensoc.com/wp-content/uploads/2023/10/Role-Icon-Shop-Preview-9.png"
+    "gensoc_server": 822411164846653490,
+    "verification_channel": 822423063697948693,
+    "this_or_that_channel": 1064462494753620010,
+    "counting_channel": 1134336873628696638,
+    "auction_channel": 1142007829478252554,
+    "welcome_channel": 822411164846653492,
+    "moderation_channel": 1167298366439428126,
+    "prev_welcome_message": 1164658878013776033,
+    "card_spam_channel": 882497725394989058,
+    "card_spam_counter": 6482,
+    "user_blacklist": [
+        1137757648071184444,
+        1149315540351983658,
+        1154774176515760210
+    ],
+    "role_colour_shop": "https://unswgensoc.com/wp-content/uploads/2023/08/Colour-Role-Preview-1.png",
+    "role_icon_shop": "https://unswgensoc.com/wp-content/uploads/2023/10/Role-Icon-Shop-Preview-9.png",
+    "verification_level": "high"
 }

--- a/misc.py
+++ b/misc.py
@@ -125,7 +125,7 @@ async def verify_form(message):
 			email = message_words[index + 1].lower()
 
 		if "your zid" in word1.lower() and message_words[index + 1].lower() != "z0000000":
-			email = message_words[index + 1].lower() + "@ad.unsw.edu.au"
+			student_email = message_words[index + 1].lower() + "@ad.unsw.edu.au"
 			unsw = True
 
 	if username == None and email == None:
@@ -159,9 +159,27 @@ async def verify_form(message):
 		await message.reply("WARNING: <@" + str(user.id) + "> account is less than 1 month old. Please manually send verification email with //send_code")
 		return None
 	'''
+	
+	config = helper.read_file("config.json")
+	verification_level = config['verification_level']
+	
+	if verification_level == "low":
+		# Verify immediately if verification level is set to low
+		await add_verified(user)
+		await message.add_reaction("✅")
+	
+	# Send verification supplied email
+	elif email != None and verification_level == "medium":
+		# Send verification to supplied email, auto verifies once code is entered
+		verification_code = generate_code(user, email, True)
+		is_sent = await send_verify_email(user, email, verification_code, True)
+		if is_sent:
+			await message.add_reaction("✅")
 
-	# Send verification email to zid or supplied email
-	if email != None:
+	elif email != None and verification_level == "high":
+		# Send verification to email or student email, auto verifies for student email
+		if unsw:
+			email = student_email
 		verification_code = generate_code(user, email, unsw)
 		is_sent = await send_verify_email(user, email, verification_code, True)
 		if is_sent:


### PR DESCRIPTION
- Added three level of verification security: low (any forms gets verified automatically), medium (any email gets verified automatically), high (only unsw students gets verified automatically)
- Fixed issue where verify_me failed to respond for non-UNSW people
- Updated help command to include new /set_verification and /modify_inventory